### PR TITLE
Content previewing fix

### DIFF
--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -26,6 +26,10 @@ class NodeSerializer(BulkSerializerMixin, serializers.ModelSerializer):
                   'sort_order', 'license_owner', 'license', 'kind', 'children', 'parent', 'content_id')
 
 class FileSerializer(serializers.ModelSerializer):
+    content_copy = serializers.FileField(use_url=False)
+
+    def get(*args, **kwargs):
+        return super.get(*args, **kwargs)
     class Meta:
         model = File
         fields = ('checksum', 'extension', 'file_size', 'content_copy', 'id', 'available', 'format')

--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -377,8 +377,7 @@ var FormatModel = BaseModel.extend({
 	get_files : function(){
 		var files = new FileCollection();
 		files.fetch({async:false});
-		//return files.where({format: this.id});
-		return files.where({id:74});
+		return files.where({format: this.id});
 	}
 });
 

--- a/contentcuration/contentcuration/static/js/edit_channel/models.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/models.js
@@ -188,9 +188,12 @@ var NodeModel = BaseModel.extend({
 						extension: "." + file_data.filename.split(".")[1]
 					});
 					file.save({
-						format: format.id
-					});
-				}
+						  format: format.id,
+          },
+          {
+              patch: true,
+          });
+        }
 			});
 		}
 	},

--- a/contentcuration/contentcuration/static/js/edit_channel/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/views.js
@@ -378,9 +378,8 @@ var BaseEditorView = BaseListView.extend({
 			entry.model.set(entry.model.attributes, {validate:true});
 			console.log("FILE SAVE", entry);
 			if(!entry.model.validationError){
-				if(!self.allow_add)
-					entry.save(entry.model.attributes, {validate:false, async:false});
-				entry.set_edited(false);
+          entry.save(entry.model.attributes, {validate:false, async:false});
+          entry.set_edited(false);
 			}else{
 				self.handle_error(entry);
 				self.errorsFound = true;


### PR DESCRIPTION
DONE:
- fix the GET serialization of `content_copy`, as to not have `127.0.0.1:8008` prepended to it. Did this by explicitly declaring the FileField to be `use_url=False`.
- Fix the URL construction of previews to correctly fetch the content.
- Properly find the files associated with a Format, by removing a hardcoded id.

![screen shot 2016-04-12 at 13 16 28](https://cloud.githubusercontent.com/assets/191955/14474229/d5f3de64-00b0-11e6-92e6-6be72653b740.png)

@jayoshih 

