### PR TITLE
ContentCuration launch tasks Continue

### DIFF
--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -297,9 +297,9 @@ def auto_delete_file_on_delete(sender, instance, **kwargs):
     Be careful! we don't know if this will work when perform bash delete on File obejcts.
     """
     if not File.objects.filter(file_on_disk=instance.file_on_disk.url):
-        content_copy_path = os.path.join(settings.STORAGE_ROOT, instance.checksum[0:1], instance.checksum[1:2], instance.checksum + instance.extension)
-        if os.path.isfile(content_copy_path):
-            os.remove(content_copy_path)
+        file_on_disk_path = os.path.join(settings.STORAGE_ROOT, instance.checksum[0:1], instance.checksum[1:2], instance.checksum + instance.extension)
+        if os.path.isfile(file_on_disk_path):
+            os.remove(file_on_disk_path)
 
 class License(models.Model):
     """

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -14,6 +14,9 @@ from django.dispatch import receiver
 
 from constants import content_kinds, extensions, presets
 
+def hyphenless_uuid():
+    return str(uuid4()).replace("-", "")
+
 def file_on_disk_name(instance, filename):
     """
     Create a name spaced file path from the File obejct's checksum property.
@@ -43,7 +46,7 @@ class FileOnDiskStorage(FileSystemStorage):
 
 class Channel(models.Model):
     """ Permissions come from association with organizations """
-    channel_id = models.UUIDField(primary_key=True, default=uuid4)
+    channel_id = models.UUIDField(primary_key=True, default=hyphenless_uuid)
     name = models.CharField(max_length=200)
     description = models.CharField(max_length=400, blank=True)
     author = models.CharField(max_length=400, blank=True)
@@ -151,7 +154,7 @@ class ContentNode(MPTTModel, models.Model):
     """
     By default, all nodes have a title and can be used as a topic.
     """
-    content_id = models.UUIDField(primary_key=False, default=uuid4, editable=False)
+    content_id = models.UUIDField(primary_key=False, default=hyphenless_uuid, editable=False)
     title = models.CharField(max_length=200)
     description = models.CharField(max_length=400, blank=True)
     kind = models.ForeignKey('ContentKind', related_name='content_metadatas', blank=True, null=True)

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -304,6 +304,8 @@ class License(models.Model):
     Normalize the license of ContentNode model
     """
     license_name = models.CharField(max_length=50)
+    license_url = models.URLField(blank=True)
+    license_description = models.TextField(blank=True)
     exists = models.BooleanField(
         default=False,
         verbose_name=_("license exists"),

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -167,6 +167,7 @@ class ContentNode(MPTTModel, models.Model):
     tags = models.ManyToManyField(ContentTag, symmetrical=False, related_name='tagged_content', blank=True)
     sort_order = models.FloatField(max_length=50, default=0, verbose_name=_("sort order"), help_text=_("Ascending, lowest number shown first"))
     license_owner = models.CharField(max_length=200, blank=True, help_text=_("Organization of person who holds the essential rights"))
+    cloned_source = TreeForeignKey('self', null=True, blank=True, models.SET_NULL, related_name='clones')
 
     created = models.DateTimeField(auto_now_add=True, verbose_name=_("created"))
     modified = models.DateTimeField(auto_now=True, verbose_name=_("modified"))

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -168,6 +168,7 @@ class ContentNode(MPTTModel, models.Model):
     sort_order = models.FloatField(max_length=50, default=0, verbose_name=_("sort order"), help_text=_("Ascending, lowest number shown first"))
     license_owner = models.CharField(max_length=200, blank=True, help_text=_("Organization of person who holds the essential rights"))
     cloned_source = TreeForeignKey('self', null=True, blank=True, models.SET_NULL, related_name='clones')
+    original_ndoe = TreeForeignKey('self', null=True, blank=True, models.SET_NULL, related_name='descendants')
 
     created = models.DateTimeField(auto_now_add=True, verbose_name=_("created"))
     modified = models.DateTimeField(auto_now=True, verbose_name=_("modified"))

--- a/contentcuration/contentcuration/models.py
+++ b/contentcuration/contentcuration/models.py
@@ -25,7 +25,7 @@ def file_on_disk_name(instance, filename):
     """
     h = instance.checksum
     basename, ext = os.path.splitext(filename)
-    return os.path.join(h[0], h[1], h + ext.lower())
+    return os.path.join(settings.STORAGE_ROOT, h[0], h[1], h + ext.lower())
 
 class FileOnDiskStorage(FileSystemStorage):
     """

--- a/contentcuration/contentcuration/serializers.py
+++ b/contentcuration/contentcuration/serializers.py
@@ -47,16 +47,16 @@ class TopicTreeSerializer(serializers.ModelSerializer):
         fields = ('name', 'channel', 'root_node', 'id')
 
 class FileSerializer(serializers.ModelSerializer):
-    content_copy = serializers.SerializerMethodField('get_file_url')
+    file_on_disk = serializers.SerializerMethodField('get_file_url')
 
     def get(*args, **kwargs):
          return super.get(*args, **kwargs)
     class Meta:
         model = File
-        fields = ('id', 'checksum', 'file_size', 'content_copy', 'contentnode', 'file_format', 'preset', 'lang','original_filename')
+        fields = ('id', 'checksum', 'file_size', 'file_on_disk', 'contentnode', 'file_format', 'preset', 'lang','original_filename')
 
     def get_file_url(self, obj):
-        return obj.content_copy.url
+        return obj.file_on_disk.url
 
 class FileFormatSerializer(serializers.ModelSerializer):
     class Meta:

--- a/contentcuration/contentcuration/settings.py
+++ b/contentcuration/contentcuration/settings.py
@@ -15,7 +15,7 @@ import os
 
 BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 
-MEDIA_ROOT = os.path.join(BASE_DIR, "content")
+STORAGE_ROOT = os.path.join(BASE_DIR, "content")
 
 STATIC_ROOT = os.path.join(BASE_DIR, "static")
 
@@ -116,10 +116,8 @@ USE_TZ = True
 
 STATIC_URL = '/static/'
 
-MEDIA_URL = '/content/'
+STORAGE_URL = '/content/'
 
 DEFAULT_FILE_STORAGE = 'kolibri.content.models.ContentCopyStorage'
 
 LOGIN_REDIRECT_URL = '/exercises/'
-
-CONTENT_COPY_DIR = MEDIA_ROOT

--- a/contentcuration/contentcuration/views.py
+++ b/contentcuration/contentcuration/views.py
@@ -96,7 +96,7 @@ def file_upload(request):
     if request.method == 'POST':
         ext = os.path.splitext(request.FILES.values()[0]._name)[1].split(".")[-1]
         original_filename = request.FILES.values()[0]._name
-        file_object = File(content_copy=request.FILES.values()[0], file_format=FileFormat.objects.get(extension=ext), original_filename = original_filename)
+        file_object = File(file_on_disk=request.FILES.values()[0], file_format=FileFormat.objects.get(extension=ext), original_filename = original_filename)
         file_object.save()
         return HttpResponse(json.dumps({
             "success": True,


### PR DESCRIPTION
I accidentally merged my PR https://github.com/fle-internal/content-curation/pull/57, I linked the commits in that PR for post-reviewing ~ 

- [x] ContentTag: remove tag_type, add channel foreign key (done at previous PR https://github.com/fle-internal/content-curation/pull/57)

- [x]  modify CustomListSerializer to adapt the new schema on ContentTag (done at previous PR https://github.com/fle-internal/content-curation/pull/57)

- [x] change content_copy to file_on_disk (done at previous PR https://github.com/fle-internal/content-curation/pull/57)

- [x] Rename MEDIA_URL to "storage"

- [x] File: clean up reference counting, just count references when we're about to delete a File (done at previous PR https://github.com/fle-internal/content-curation/pull/57)

- [x] License: add license url and license text field

- [x] License: Replace "exists" text field with granular permissions based on license

- [x] Channel: remove dashes from UUIDField

- [x] ContentNode: add cloned_source field that foreign keys to the node you just copied from; change foreign key cascase behaviour to SET_NULL

- [x] ContentNode: add original_node field that points to the very original node we copied from; set to self when creating a new node; set foreign key cascade behaviour to SET_NULL

- [x] ContentNode: remove dashes from content_id