### PR TITLE
Update content_id duplication logic

### DIFF
--- a/contentcuration/contentcuration/views.py
+++ b/contentcuration/contentcuration/views.py
@@ -213,7 +213,8 @@ def _duplicate_node(node, sort_order=1, parent=None):
         changed=True,
         original_node=node.original_node or node,
         cloned_source=node,
-        author=node.author
+        author=node.author,
+        content_id=node.content_id,
     )
 
     # add tags now


### PR DESCRIPTION
Added content_id to duplication logic so that when a curator imports from another channel, kolibri progress will be retained