### PR TITLE
Update share_editor_item.handlebars

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/share/hbtemplates/share_editor_item.handlebars
+++ b/contentcuration/contentcuration/static/js/edit_channel/share/hbtemplates/share_editor_item.handlebars
@@ -8,6 +8,6 @@
 		<span class="pending_indicator">Pending...</span>
 		<span class="reinvite_editor glyphicon glyphicon-envelope" title="Resend Invitation"></span>
 	{{/if}}
-	<span class="remove_editor glyphicon glyphicon-remove" title="Remove Editor"></span>
+	<!--<span class="remove_editor glyphicon glyphicon-remove" title="Remove Editor"></span>-->
 {{/if}}
 </div>


### PR DESCRIPTION
Temporarily comment out ability to remove editors to avoid bugs related to deleting editors