### PR TITLE
Pointing lessify to @dxcanas version

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "mathjax": "^2.7.0",
     "mathquill": "^0.10.1-a",
     "minifyify": "^7.0.3",
-    "node-lessify": "^0.0.11",
+    "node-lessify": "https://github.com/DXCanas/node-lessify.git",
     "summernote": "^0.8.2",
     "to-markdown": "^3.0.3",
     "underscore": "^1.8.3",


### PR DESCRIPTION
Lessify had some issues that needed to be resolved. Applied the pending PRs that allow for things like global styles, also brought in my own changes so that we can gracefully recover from less errors.

If i end up getting the npm packages, I'll change it back.

Suggested order of commands after merge:
```
npm cache clear
npm remove node-lessify
npm install
```

Then just build as usual!

See changes to lessify here:

https://github.com/DXCanas/node-lessify/blob/master/README.md

If you're interested