### PR TITLE
Adding promise polyfill

### DIFF
--- a/contentcuration/contentcuration/static/js/bundle_modules/base.js
+++ b/contentcuration/contentcuration/static/js/bundle_modules/base.js
@@ -1,62 +1,66 @@
-var attachfastclick = require("fastclick");
+var attachfastclick = require('fastclick');
 
-var $ = require("jquery");
-var get_cookie = require("utils/get_cookie");
+var $ = require('jquery');
+var get_cookie = require('utils/get_cookie');
 global.$ = $;
 global.jQuery = $;
-require("handlebars/helpers");
+require('handlebars/helpers');
 
-require("../../less/styles.less");
-require("bootstrap/dist/js/npm.js");
-require("../../js/utils/jquery-ui");
-// require("../../../../../node_modules/jquery-ui/ui/widgets/sortable");
+require('../../less/styles.less');
+require('bootstrap/dist/js/npm.js');
+require('../../js/utils/jquery-ui');
 
-var csrftoken = get_cookie("csrftoken") || "";
+// Promise polyfill
+if(!global.Promise) {
+  global.Promise = require('promise-polyfill');
+}
+
+var csrftoken = get_cookie('csrftoken') || '';
 
 function csrfSafeMethod(method) {
     // these HTTP methods do not require CSRF protection
-    return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
+  return (/^(GET|HEAD|OPTIONS|TRACE)$/.test(method));
 }
 
 function sameOrigin(url) {
     // test that a given url is a same-origin URL
     // url could be relative or scheme relative or absolute
-    var host = document.location.host; // host + port
-    var protocol = document.location.protocol;
-    var sr_origin = '//' + host;
-    var origin = protocol + sr_origin;
+  var host = document.location.host; // host + port
+  var protocol = document.location.protocol;
+  var sr_origin = '//' + host;
+  var origin = protocol + sr_origin;
     // Allow absolute or scheme relative URLs to same origin
-    return (url === origin || url.slice(0, origin.length + 1) === origin + '/') ||
+  return (url === origin || url.slice(0, origin.length + 1) === origin + '/') ||
         (url === sr_origin || url.slice(0, sr_origin.length + 1) === sr_origin + '/') ||
         // or any other URL that isn't scheme relative or absolute i.e relative.
         !(/^(\/\/|http:|https:).*/.test(url));
 }
 
 $.ajaxSetup({
-    cache: false,
-    beforeSend: function(xhr, settings) {
-		if (!csrfSafeMethod(settings.type) && sameOrigin(settings.url)) {
+  cache: false,
+  beforeSend: function(xhr, settings) {
+    if (!csrfSafeMethod(settings.type) && sameOrigin(settings.url)) {
             // Send the token to same-origin, relative URLs only.
             // Send the token only if the method warrants CSRF protection
             // Using the CSRFToken value acquired earlier
-            xhr.setRequestHeader("X-CSRFToken", csrftoken);
-        }
-	}
+      xhr.setRequestHeader('X-CSRFToken', csrftoken);
+    }
+  }
 });
 
-$.extend( $.expr[ ":" ], {
-    data: $.expr.createPseudo ?
+$.extend( $.expr[ ':' ], {
+  data: $.expr.createPseudo ?
         $.expr.createPseudo(function( dataName ) {
-            return function( elem ) {
-                return !!$.data( elem, dataName );
-            };
+          return function( elem ) {
+            return !!$.data( elem, dataName );
+          };
         }) :
         // support: jQuery <1.8
         function( elem, i, match ) {
-            return !!$.data( elem, match[ 3 ] );
+          return !!$.data( elem, match[ 3 ] );
         }
 });
 
 $(function() {
-    attachfastclick(document.body);
+  attachfastclick(document.body);
 });

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "mathquill": "^0.10.1-a",
     "minifyify": "^7.0.3",
     "node-lessify": "https://github.com/DXCanas/node-lessify.git",
+    "promise-polyfill": "^6.0.2",
     "summernote": "^0.8.2",
     "to-markdown": "^3.0.3",
     "underscore": "^1.8.3",


### PR DESCRIPTION
Using [this package](https://www.npmjs.com/package/promise-polyfill), promise support goes back to IE8.

Was going to try and employ [this technique](https://philipwalton.com/articles/loading-polyfills-only-when-needed/) so that we wouldn't even load the code, but it seemed like it might be a little messy to write a script outside of `base.js` (already dedicated to preparing the environment). @rtibbles thoughts? and if I do employ the implementation he suggests, where should I put that code? inside a `<script>` tag in [`base.html`](https://github.com/fle-internal/content-curation/blob/develop/contentcuration/contentcuration/templates/base.html)?