### PR TITLE
Add tracing decorator over convert_data_to_nodes

### DIFF
--- a/contentcuration/contentcuration/utils/logging.py
+++ b/contentcuration/contentcuration/utils/logging.py
@@ -1,0 +1,6 @@
+def trace(f):
+    try:
+        import newrelic.agent
+        return newrelic.agent.function_trace(f)
+    except ImportError:
+        return f

--- a/contentcuration/contentcuration/view/internal_views.py
+++ b/contentcuration/contentcuration/view/internal_views.py
@@ -19,6 +19,7 @@ from contentcuration.models import Exercise, AssessmentItem, Channel, License, F
 from contentcuration import ricecooker_versions as rc
 from le_utils.constants import content_kinds
 from django.db.models.functions import Concat
+from contentcuration.contentcuration.utils.logging import trace
 from django.core.files import File as DjFile
 from django.db.models import Q, Value
 from django.db import transaction
@@ -233,6 +234,8 @@ def create_channel(channel_data, user):
 
     return channel # Return new channel
 
+
+@trace
 def convert_data_to_nodes(content_data, parent_node):
     """ Parse dict and create nodes accordingly """
     try:


### PR DESCRIPTION
Add a trace function to trace functions that aren't automatically traced by our newrelic tracer. 