### PR TITLE
Add prettier deps, eslint config, pre-commit hook

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,18 @@
+plugins:
+  - prettier
+extends:
+  - eslint:recommended
+  - prettier
+rules:
+  prettier/prettier:
+    - error
+    -
+      printWidth: 100
+      trailingComma: es5
+      singleQuote: true
+env:
+  browser: true
+  commonjs: true
+  jquery: true
+globals:
+  Promise: true

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "lint:py": "flake8 --exit-zero"
+    "lint:py": "flake8 --exit-zero",
+    "precommit": "lint-staged"
   },
   "repository": {
     "type": "git",
@@ -51,5 +52,19 @@
     "to-markdown": "^3.0.3",
     "underscore": "^1.8.3",
     "watchify": "^3.2.3"
+  },
+  "devDependencies": {
+    "eslint": "^4.1.1",
+    "eslint-config-prettier": "^2.3.0",
+    "eslint-plugin-prettier": "^2.1.2",
+    "husky": "^0.14.2",
+    "lint-staged": "^4.0.0",
+    "prettier": "^1.5.2"
+  },
+  "lint-staged": {
+    "*.js": [
+      "prettier --write --print-width 100 --trailing-comma es5 --single-quote",
+      "git add"
+    ]
   }
 }


### PR DESCRIPTION
This adds eslint, prettier, plus husky/lint-stage to enable linting and code formatting.

ESLint allows developers to see potential bugs and style violations via the terminal or through an editor integration.

Prettier is a code formatting tool and is configured to be run during a pre-commit hook using the husky/lint-stage dependencies. This means if you are committing a change to `foo.js`, Prettier will first auto-format it before committing to the git tree. In the short term, this means small edits to files will result in large changesets as the codebase gradually incorporates the standard code style.

As an example, the file `build.js` was run through the pre-commit hook, hence the large number of changes.

eslint-plugin/config-prettier was also added, which provides a way for eslint and prettier to work together in harmony.