### PR TITLE
add jpeg decoder package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /contentcuration
 # Generate the gcloud debugger context file
 RUN gcloud debug source gen-repo-info-file --output-directory=/contentcuration/contentcuration/
 
+RUN apt-get install -y libjpeg-dev
 RUN pip install -r requirements.txt
 RUN pip install -r requirements_prod.txt
 RUN npm install -g yarn


### PR DESCRIPTION
Added `libjpeg-dev` for `Pillow` so that we can have the jpeg decoder. 

Here is the test result showing that jpeg support is now available:

```
--------------------------------------------------------------------
  PIL SETUP SUMMARY
  --------------------------------------------------------------------
  version      Pillow 2.8.1
  platform     linux2 2.7.12 (default, Nov 19 2016, 06:48:10)
               [GCC 5.4.0 20160609]
  --------------------------------------------------------------------
  *** TKINTER support not available
  (Tcl/Tk 8.6 libraries needed)
  --- JPEG support available
  *** OPENJPEG (JPEG2000) support not available
  --- ZLIB (PNG/ZIP) support available
  *** LIBTIFF support not available
  *** FREETYPE2 support not available
  *** LITTLECMS2 support not available
  *** WEBP support not available
  *** WEBPMUX support not available
  --------------------------------------------------------------------
```