### PR TITLE
Show an error when importCollection.duplicate fails

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/import/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/import/views.js
@@ -83,6 +83,8 @@ var ImportModalView = BaseViews.BaseView.extend({
           return this._showWarning();
         case 'success':
           return this._finishImport();
+        case 'failure':
+          return this.trigger('finish_import', true);
         default:
           return;
       }
@@ -128,10 +130,14 @@ var ImportModalView = BaseViews.BaseView.extend({
 
     _startImport: function() {
         var self = this;
-        function onFinishImport(resolve) {
-            self.once('finish_import', function() {
+        function onFinishImport(resolve, reject) {
+            self.once('finish_import', function(failed = false) {
                 self.ImportModal.closeModal();
-                resolve(true);
+                if (failed) {
+                    reject();
+                } else {
+                  resolve(true);
+                }
             });
         }
         this.listView.display_load(this.get_translation("importing_content"), onFinishImport);

--- a/contentcuration/contentcuration/static/js/edit_channel/import/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/import/views.js
@@ -131,9 +131,9 @@ var ImportModalView = BaseViews.BaseView.extend({
     _startImport: function() {
         var self = this;
         function onFinishImport(resolve, reject) {
-            self.once('finish_import', function(failed = false) {
+            self.once('finish_import', function(importFailed) {
                 self.ImportModal.closeModal();
-                if (failed) {
+                if (importFailed) {
                     reject();
                 } else {
                   resolve(true);
@@ -144,7 +144,7 @@ var ImportModalView = BaseViews.BaseView.extend({
     },
 
     _finishImport: function() {
-      this.trigger('finish_import');
+      this.trigger('finish_import', false);
     }
 });
 

--- a/contentcuration/contentcuration/static/js/edit_channel/import/vuex/importActions.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/import/vuex/importActions.js
@@ -51,6 +51,10 @@ exports.copyImportListToChannel = function(context, payload) {
   .then(function onSuccess(collection) {
     context.commit('UPDATE_IMPORT_STATUS', 'success');
     payload.onConfirmImport(collection);
+  })
+  .catch(function onFailure(error) {
+    console.error(error);
+    context.commit('UPDATE_IMPORT_STATUS', 'failure');
   });
 }
 


### PR DESCRIPTION
UI handles the error case when `importCollection.duplicate` fails (e.g. during timeout)

![import error](https://user-images.githubusercontent.com/10248067/33343766-5e0854ba-d43b-11e7-8606-8e5f475beb49.gif)
