### PR TITLE
Two small fixes around exercises

### DIFF
--- a/contentcuration/contentcuration/static/js/edit_channel/exercise_creation/views.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/exercise_creation/views.js
@@ -1,6 +1,6 @@
 /* CONSTANTS */
 const CHARACTERS = require("./symbols.json");
-const MATHJAX_REGEX = /\$\$([^\$]+)\$\$/g;
+const MATHJAX_REGEX = /\$\$([^\$]+)\$\$/g;      // <-- this is not used
 const IMG_PLACEHOLDER = "${☣ CONTENTSTORAGE}/"
 const IMG_REGEX = /\${☣ CONTENTSTORAGE}\/([^)]+)/g;
 const NUM_REGEX = /[0-9\,\.\-\/\+e\s]+/g;
@@ -529,7 +529,7 @@ var EditorView = BaseViews.BaseView.extend({
     replace_mathjax_with_katex: function(content, callback){
         var matches = this.get_mathjax_strings(content);
         matches.forEach(function(match){
-            var replace_str = Katex.renderToString(match.match(/\$\$(.+)\$\$/)[1]);
+            var replace_str = Katex.renderToString(match.match(/\$\$(.+?)\$\$/)[1]);
             content = content.replace(match, replace_str);
         });
         callback(content);

--- a/contentcuration/contentcuration/static/js/edit_channel/utils/mathjaxtosvg.js
+++ b/contentcuration/contentcuration/static/js/edit_channel/utils/mathjaxtosvg.js
@@ -53,7 +53,7 @@ function init(){
   head.appendChild(script);
   script = document.createElement("script");
   script.type = "text/javascript";
-  script.src  = "https://cdn.mathjax.org/mathjax/latest/MathJax.js";
+  script.src  = "https://cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js";
   script.onload = function(){
     //  Cache a callback to the GenerateSVG action
     SvgGenerator.generate = MathJax.Callback(["GenerateSVG",SvgGenerator]);


### PR DESCRIPTION
1. change CDN used to load MathJax referenced in `edit_channel/utils/mathjaxtosvg.js`
2. change REGEX used by `replace_mathjax_with_katex` to be non-greedy to avoid problems like this

<img width="848" alt="fixed by making regex non greedy" src="https://user-images.githubusercontent.com/163966/36607665-4b69fc48-1895-11e8-928b-2aadb16e0932.png">
